### PR TITLE
Add manifest for workload cluster deployed with eksctl

### DIFF
--- a/releases/23.1/amazon-eks/multi-cluster/distributed_cluster_with_eksctl.yaml
+++ b/releases/23.1/amazon-eks/multi-cluster/distributed_cluster_with_eksctl.yaml
@@ -1,0 +1,297 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: contrail
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: contrail-deploy
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: contrail-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: contrail-deploy-serviceaccount
+  namespace: contrail-deploy
+imagePullSecrets:
+- name: registrypullsecret
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: contrail-system-serviceaccount
+  namespace: contrail-system
+imagePullSecrets:
+- name: registrypullsecret
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: contrail-serviceaccount
+  namespace: contrail
+imagePullSecrets:
+- name: registrypullsecret
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: contrail-deploy-role
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: contrail-role
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: contrail-system-role
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: contrail-deploy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: contrail-deploy-role
+subjects:
+- kind: ServiceAccount
+  name: contrail-deploy-serviceaccount
+  namespace: contrail-deploy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: contrail-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: contrail-role
+subjects:
+- kind: ServiceAccount
+  name: contrail-serviceaccount
+  namespace: contrail
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: contrail-system-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: contrail-system-role
+subjects:
+- kind: ServiceAccount
+  name: contrail-system-serviceaccount
+  namespace: contrail-system
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: <base64-encoded-credential>
+kind: Secret
+metadata:
+  name: registrypullsecret
+  namespace: contrail-deploy
+type: kubernetes.io/dockerconfigjson
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: <base64-encoded-credential>
+kind: Secret
+metadata:
+  name: registrypullsecret
+  namespace: contrail-system
+type: kubernetes.io/dockerconfigjson
+---
+apiVersion: v1
+data:
+  .dockerconfigjson: <base64-encoded-credential>
+kind: Secret
+metadata:
+  name: registrypullsecret
+  namespace: contrail
+type: kubernetes.io/dockerconfigjson
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    secret: ""
+  name: contrail-k8s-deployer
+  namespace: contrail-deploy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: contrail-k8s-deployer
+  template:
+    metadata:
+      labels:
+        app: contrail-k8s-deployer
+    spec:
+      containers:
+      - command:
+        - /manager
+        - --metrics-addr
+        - 127.0.0.1:8081
+        - -central-cluster-config-path
+        - /etc/config/central/kubeconfig
+        image: enterprise-hub.juniper.net/contrail-container-prod/contrail-k8s-deployer:23.1.0.282
+        name: contrail-k8s-deployer
+        volumeMounts:
+        - mountPath: /etc/config/central
+          name: kubeconfig
+          readOnly: true
+      hostNetwork: true
+      initContainers:
+      - command:
+        - kubectl
+        - apply
+        - -k
+        - /distributed-crd
+        image: enterprise-hub.juniper.net/contrail-container-prod/contrail-k8s-distributed-crdloader:23.1.0.282
+        name: contrail-k8s-distributed-crdloader
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 3000
+        runAsNonRoot: true
+        runAsUser: 1000
+      serviceAccountName: contrail-deploy-serviceaccount
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      volumes:
+      - name: kubeconfig
+        secret:
+          items:
+          - key: kubeconfig
+            path: kubeconfig
+          secretName: access-central
+---
+apiVersion: v1
+data:
+  contrail-dist-cr.yaml: |
+    apiVersion: configplane.juniper.net/v1alpha1
+    kind: ContrailCertificateManager
+    metadata:
+      name: contrailcertificatemanager
+      namespace: contrail
+    spec:
+      common:
+        containers:
+        - image: enterprise-hub.juniper.net/contrail-container-prod/contrail-k8s-cert-manager:23.1.0.282
+          name: contrail-k8s-cert-generator
+        - image: enterprise-hub.juniper.net/contrail-container-prod/cert-manager-controller:v1.8.2
+          name: cert-manager
+        - image: enterprise-hub.juniper.net/contrail-container-prod/cert-manager-webhook:v1.8.2
+          name: cert-manager-webhook
+        - image: enterprise-hub.juniper.net/contrail-container-prod/cert-manager-cainjector:v1.8.2
+          name: cert-manager-cainjector
+      generatorType: cert-manager
+      secrets:
+      - components:
+        - vrouter-xmpp
+        name: xmpp-tls-vrouter-agent
+        namespace: contrail
+      - components:
+        - vrouter-sandesh
+        name: sandesh-tls-vrouter-agent
+        namespace: contrail
+      - name: introspect-tls-client
+        namespace: contrail
+      - name: telemetry-exporter-tls
+        namespace: contrail
+    ---
+    apiVersion: dataplane.juniper.net/v1alpha1
+    kind: Vrouter
+    metadata:
+      name: contrail-vrouter-nodes
+      namespace: contrail
+    spec:
+      agent:
+        default:
+          collectors:
+          - localhost:6700
+          xmppAuthEnable: true
+        sandesh:
+          introspectSslEnable: true
+      clusterName: workload-cluster
+      common:
+        containers:
+        - image: enterprise-hub.juniper.net/contrail-container-prod/contrail-vrouter-agent:23.1.0.282
+          name: contrail-vrouter-agent
+        - image: enterprise-hub.juniper.net/contrail-container-prod/contrail-init:23.1.0.282
+          name: contrail-watcher
+        - image: enterprise-hub.juniper.net/contrail-container-prod/contrail-telemetry-exporter:23.1.0.282
+          name: contrail-vrouter-telemetry-exporter
+        initContainers:
+        - image: enterprise-hub.juniper.net/contrail-container-prod/contrail-init:23.1.0.282
+          name: contrail-init
+        - image: enterprise-hub.juniper.net/contrail-container-prod/contrail-cni-init:23.1.0.282
+          name: contrail-cni-init
+      maxUnavailablePercentage: 100%
+kind: ConfigMap
+metadata:
+  name: contrail-workload-cr
+  namespace: contrail
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: apply-contrail
+  namespace: contrail
+spec:
+  backoffLimit: 4
+  template:
+    spec:
+      containers:
+      - command:
+        - /applier.sh
+        - vrouters.dataplane.juniper.net
+        - contrail-dist-cr.yaml
+        image: enterprise-hub.juniper.net/contrail-container-prod/contrail-k8s-applier:23.1.0.282
+        name: applier
+        volumeMounts:
+        - mountPath: /tmp/contrail
+          name: cr-volume
+      hostNetwork: true
+      restartPolicy: Never
+      serviceAccountName: contrail-serviceaccount
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      volumes:
+      - configMap:
+          name: contrail-workload-cr
+        name: cr-volume


### PR DESCRIPTION
This manifests contain all required objects and can be applied before adding nodegroups to cluster, so it's easier to use in scripts or other automations.